### PR TITLE
added image support example - RGBA to UIImage and vice versa

### DIFF
--- a/iOSDeepLearningKitApp/iOSDeepLearningKitApp/iOSDeepLearningKitApp.xcodeproj/project.pbxproj
+++ b/iOSDeepLearningKitApp/iOSDeepLearningKitApp/iOSDeepLearningKitApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		67B14E591C6FED2800FCB69C /* nin_cifar10_full.json in Resources */ = {isa = PBXBuildFile; fileRef = 67B14E581C6FED2800FCB69C /* nin_cifar10_full.json */; };
 		67B14E5B1C6FED2D00FCB69C /* pool1.json in Resources */ = {isa = PBXBuildFile; fileRef = 67B14E5A1C6FED2D00FCB69C /* pool1.json */; };
 		67B14E5D1C6FED8A00FCB69C /* conv1.json in Resources */ = {isa = PBXBuildFile; fileRef = 67B14E5C1C6FED8A00FCB69C /* conv1.json */; };
+		6B57D62F1C82E16F0082387B /* UIImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B57D62E1C82E16F0082387B /* UIImageExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		67B14E581C6FED2800FCB69C /* nin_cifar10_full.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = nin_cifar10_full.json; sourceTree = "<group>"; };
 		67B14E5A1C6FED2D00FCB69C /* pool1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = pool1.json; sourceTree = "<group>"; };
 		67B14E5C1C6FED8A00FCB69C /* conv1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = conv1.json; sourceTree = "<group>"; };
+		6B57D62E1C82E16F0082387B /* UIImageExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +90,7 @@
 		67B14E2D1C6FE91400FCB69C /* iOSDeepLearningKitApp */ = {
 			isa = PBXGroup;
 			children = (
+				6B57D62D1C82E1460082387B /* ThirdParty */,
 				67B14E2E1C6FE91400FCB69C /* AppDelegate.swift */,
 				67B14E301C6FE91400FCB69C /* ViewController.swift */,
 				67B14E321C6FE91400FCB69C /* Main.storyboard */,
@@ -109,6 +112,14 @@
 				67B14E3A1C6FE91400FCB69C /* Info.plist */,
 			);
 			path = iOSDeepLearningKitApp;
+			sourceTree = "<group>";
+		};
+		6B57D62D1C82E1460082387B /* ThirdParty */ = {
+			isa = PBXGroup;
+			children = (
+				6B57D62E1C82E16F0082387B /* UIImageExtension.swift */,
+			);
+			name = ThirdParty;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -195,6 +206,7 @@
 				67B14E2F1C6FE91400FCB69C /* AppDelegate.swift in Sources */,
 				67B14E4F1C6FECE500FCB69C /* DeepNetwork+JSON.swift in Sources */,
 				67B14E531C6FED0300FCB69C /* ConvolutionLayer.swift in Sources */,
+				6B57D62F1C82E16F0082387B /* UIImageExtension.swift in Sources */,
 				67B14E571C6FED1200FCB69C /* RectifierLayer.swift in Sources */,
 				67B14E551C6FED0D00FCB69C /* PoolingLayer.swift in Sources */,
 				67B14E491C6FECAD00FCB69C /* MetalUtilityFunctions.swift in Sources */,
@@ -347,6 +359,7 @@
 				67B14E3F1C6FE91400FCB69C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/iOSDeepLearningKitApp/iOSDeepLearningKitApp/iOSDeepLearningKitApp/Base.lproj/Main.storyboard
+++ b/iOSDeepLearningKitApp/iOSDeepLearningKitApp/iOSDeepLearningKitApp/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15A279b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15A279b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <scenes>
         <!--View Controller-->

--- a/iOSDeepLearningKitApp/iOSDeepLearningKitApp/iOSDeepLearningKitApp/UIImageExtension.swift
+++ b/iOSDeepLearningKitApp/iOSDeepLearningKitApp/iOSDeepLearningKitApp/UIImageExtension.swift
@@ -1,0 +1,263 @@
+//
+//  UIImageExtension.swift
+//  ImageFun - original source project: https://github.com/kNeerajPro/ImagePixelFun
+//             cloned and adapted to Swift 2.x: https://github.com/DeepLearningKit/ImagePixelFun
+//  (ImageFun is also Apache 2.0 open source licence)
+//
+//  Created by Neeraj Kumar on 11/11/14.
+//  Copyright (c) 2014 Neeraj Kumar. All rights reserved.
+//  (minor adaptions to Swift 2.x by Amund Tveit - 2016)
+//
+
+import Foundation
+import UIKit
+
+private extension UIImage {
+    private func createARGBBitmapContext(inImage: CGImageRef) -> CGContext {
+        
+        //Get image width, height
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        
+        // Declare the number of bytes per row. Each pixel in the bitmap in this
+        // example is represented by 4 bytes; 8 bits each of red, green, blue, and
+        // alpha.
+        let bitmapBytesPerRow = Int(pixelsWide) * 4
+        let bitmapByteCount = bitmapBytesPerRow * Int(pixelsHigh)
+        
+        // Use the generic RGB color space.
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        
+        // Allocate memory for image data. This is the destination in memory
+        // where any drawing to the bitmap context will be rendered.
+        var bitmapData = UnsafeMutablePointer<UInt8>()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.PremultipliedFirst.rawValue)
+        
+        // Create the bitmap context. We want pre-multiplied ARGB, 8-bits
+        // per component. Regardless of what the source image format is
+        // (CMYK, Grayscale, and so on) it will be converted over to the format
+        // specified here by CGBitmapContextCreate.
+        let context = CGBitmapContextCreate(bitmapData, pixelsWide, pixelsHigh, 8, bitmapBytesPerRow, colorSpace, bitmapInfo.rawValue)
+        
+        return context!
+    }
+    
+    func sanitizePoint(point:CGPoint) {
+        let inImage:CGImageRef = self.CGImage!
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        precondition(CGRectContainsPoint(rect, point), "CGPoint passed is not inside the rect of image.It will give wrong pixel and may crash.")
+    }
+}
+
+
+// Internal functions exposed.Can be public.
+
+extension  UIImage {
+    public typealias RawColorType = (newRedColor:UInt8, newgreenColor:UInt8, newblueColor:UInt8,  newalphaValue:UInt8)
+    
+    
+    /*
+    Change the color of pixel at a certain point.If you want more control try block based method to modify pixels.
+    */
+    public func setPixelColorAtPoint(point:CGPoint, color: RawColorType) -> UIImage? {
+        self.sanitizePoint(point)
+        let inImage:CGImageRef = self.CGImage!
+        let context = self.createARGBBitmapContext(inImage)
+        
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        //Clear the context
+        CGContextClearRect(context, rect)
+        
+        // Draw the image to the bitmap context. Once we draw, the memory
+        // allocated for the context for rendering will then contain the
+        // raw image data in the specified color space.
+        CGContextDrawImage(context, rect, inImage)
+        
+        // Now we can get a pointer to the image data associated with the bitmap
+        // context.
+        var data = CGBitmapContextGetData(context)
+        var dataType = UnsafeMutablePointer<UInt8>(data)
+        
+        let offset = 4*((Int(pixelsWide) * Int(point.y)) + Int(point.x))
+        dataType[offset]   = color.newalphaValue
+        dataType[offset+1] = color.newRedColor
+        dataType[offset+2] = color.newgreenColor
+        dataType[offset+3] = color.newblueColor
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.PremultipliedFirst.rawValue)
+        
+        let bitmapBytesPerRow = Int(pixelsWide) * 4
+        let bitmapByteCount = bitmapBytesPerRow * Int(pixelsHigh)
+        
+        let finalcontext = CGBitmapContextCreate(data, pixelsWide, pixelsHigh, 8, bitmapBytesPerRow, colorSpace, bitmapInfo.rawValue)
+        
+        let imageRef = CGBitmapContextCreateImage(finalcontext)
+        return UIImage(CGImage: imageRef!, scale: self.scale,orientation: self.imageOrientation)
+        
+    }
+    
+    
+    /*
+    Get pixel color for a pixel in the image.
+    */
+    func getPixelColorAtLocation(point:CGPoint)->UIColor? {
+        self.sanitizePoint(point)
+        // Create off screen bitmap context to draw the image into. Format ARGB is 4 bytes for each pixel: Alpa, Red, Green, Blue
+        let inImage:CGImageRef = self.CGImage!
+        let context = self.createARGBBitmapContext(inImage)
+        
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        //Clear the context
+        CGContextClearRect(context, rect)
+        
+        // Draw the image to the bitmap context. Once we draw, the memory
+        // allocated for the context for rendering will then contain the
+        // raw image data in the specified color space.
+        CGContextDrawImage(context, rect, inImage)
+        
+        // Now we can get a pointer to the image data associated with the bitmap
+        // context.
+        let data = CGBitmapContextGetData(context)
+        let dataType = UnsafePointer<UInt8>(data)
+        
+        let offset = 4*((Int(pixelsWide) * Int(point.y)) + Int(point.x))
+        let alphaValue = dataType[offset]
+        let redColor = dataType[offset+1]
+        let greenColor = dataType[offset+2]
+        let blueColor = dataType[offset+3]
+        
+        let redFloat = CGFloat(redColor)/255.0
+        let greenFloat = CGFloat(greenColor)/255.0
+        let blueFloat = CGFloat(blueColor)/255.0
+        let alphaFloat = CGFloat(alphaValue)/255.0
+        
+        return UIColor(red: redFloat, green: greenFloat, blue: blueFloat, alpha: alphaFloat)
+        
+        // When finished, release the context
+        // Free image data memory for the context
+    }
+    
+    
+    // Get grayscale image from normal image.
+    
+    func getGrayScale() -> UIImage? {
+        let inImage:CGImageRef = self.CGImage!
+        let context = self.createARGBBitmapContext(inImage)
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        let bitmapBytesPerRow = Int(pixelsWide) * 4
+        let bitmapByteCount = bitmapBytesPerRow * Int(pixelsHigh)
+        
+        //Clear the context
+        CGContextClearRect(context, rect)
+        
+        // Draw the image to the bitmap context. Once we draw, the memory
+        // allocated for the context for rendering will then contain the
+        // raw image data in the specified color space.
+        CGContextDrawImage(context, rect, inImage)
+        
+        // Now we can get a pointer to the image data associated with the bitmap
+        // context.
+        
+        
+        var data = CGBitmapContextGetData(context)
+        var dataType = UnsafeMutablePointer<UInt8>(data)
+        let point: CGPoint = CGPointMake(0, 0)
+        
+        for var x = 0; x < Int(pixelsWide) ; x++ {
+            for var y = 0; y < Int(pixelsHigh) ; y++ {
+                let offset = 4*((Int(pixelsWide) * Int(y)) + Int(x))
+                let alpha = dataType[offset]
+                let red = dataType[offset+1]
+                let green = dataType[offset+2]
+                let blue = dataType[offset+3]
+                
+                let avg = (UInt32(red) + UInt32(green) + UInt32(blue))/3
+                
+                dataType[offset + 1] = UInt8(avg)
+                dataType[offset + 2] = UInt8(avg)
+                dataType[offset + 3] = UInt8(avg)
+            }
+        }
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.PremultipliedFirst.rawValue)
+        
+        let finalcontext = CGBitmapContextCreate(data, pixelsWide, pixelsHigh, 8,  bitmapBytesPerRow, colorSpace, bitmapInfo.rawValue)
+        
+        let imageRef = CGBitmapContextCreateImage(finalcontext)
+        return UIImage(CGImage: imageRef!, scale: self.scale,orientation: self.imageOrientation)
+    }
+    
+    
+    
+    // Defining the closure.
+    typealias ModifyPixelsClosure = (point:CGPoint, redColor:UInt8, greenColor:UInt8, blueColor:UInt8, alphaValue:UInt8)->(newRedColor:UInt8, newgreenColor:UInt8, newblueColor:UInt8,  newalphaValue:UInt8)
+    
+    
+    // Provide closure which will return new color value for pixel using any condition you want inside the closure.
+    
+    func applyOnPixels(closure:ModifyPixelsClosure) -> UIImage? {
+        let inImage:CGImageRef = self.CGImage!
+        let context = self.createARGBBitmapContext(inImage)
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        let bitmapBytesPerRow = Int(pixelsWide) * 4
+        let bitmapByteCount = bitmapBytesPerRow * Int(pixelsHigh)
+        
+        //Clear the context
+        CGContextClearRect(context, rect)
+        
+        // Draw the image to the bitmap context. Once we draw, the memory
+        // allocated for the context for rendering will then contain the
+        // raw image data in the specified color space.
+        CGContextDrawImage(context, rect, inImage)
+        
+        // Now we can get a pointer to the image data associated with the bitmap
+        // context.
+        
+        
+        var data = CGBitmapContextGetData(context)
+        var dataType = UnsafeMutablePointer<UInt8>(data)
+        let point: CGPoint = CGPointMake(0, 0)
+        
+        for var x = 0; x < Int(pixelsWide) ; x++ {
+            for var y = 0; y < Int(pixelsHigh) ; y++ {
+                let offset = 4*((Int(pixelsWide) * Int(y)) + Int(x))
+                let alpha = dataType[offset]
+                let red = dataType[offset+1]
+                let green = dataType[offset+2]
+                let blue = dataType[offset+3]
+                //                let (newRedColor:UInt8, newGreenColor:UInt8?, newBlueColor:UInt8?, newAlphaValue:UInt8?)  =  closure(point: CGPointMake(CGFloat(x), CGFloat(y)), redColor: red, greenColor: green,  blueColor: blue, alphaValue: alpha)
+                let (newRedColor, newGreenColor, newBlueColor, newAlphaValue)  =  closure(point: CGPointMake(CGFloat(x), CGFloat(y)), redColor: red, greenColor: green,  blueColor: blue, alphaValue: alpha)
+                dataType[offset] = newAlphaValue
+                dataType[offset + 1] = newRedColor
+                dataType[offset + 2] = newGreenColor
+                dataType[offset + 3] = newBlueColor
+            }
+        }
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.PremultipliedFirst.rawValue)
+        
+        let finalcontext = CGBitmapContextCreate(data, pixelsWide, pixelsHigh, 8,  bitmapBytesPerRow, colorSpace, bitmapInfo.rawValue)
+        
+        let imageRef = CGBitmapContextCreateImage(finalcontext)
+        return UIImage(CGImage: imageRef!, scale: self.scale,orientation: self.imageOrientation)
+    }
+    
+}

--- a/iOSDeepLearningKitApp/iOSDeepLearningKitApp/iOSDeepLearningKitApp/ViewController.swift
+++ b/iOSDeepLearningKitApp/iOSDeepLearningKitApp/iOSDeepLearningKitApp/ViewController.swift
@@ -11,8 +11,8 @@ import UIKit
 class ViewController: UIViewController {
     
     var deepNetwork: DeepNetwork!
-
-
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
@@ -25,6 +25,9 @@ class ViewController: UIViewController {
         // conv1.json contains a cifar 10 image of a cat
         let conv1Layer = deepNetwork.loadJSONFile("conv1")!
         let image: [Float] = conv1Layer["input"] as! [Float]
+        
+        // shows a tiny (32x32) CIFAR 10 image on screen
+        showCIFARImage(image)
         
         
         var randomimage = createFloatNumbersArray(image.count)
@@ -51,13 +54,54 @@ class ViewController: UIViewController {
         deepNetwork.loadDeepNetworkFromJSON("nin_cifar10_full", inputImage: image, inputShape: imageShape,caching_mode:caching_mode)
         deepNetwork.classify(image)
         
-        exit(0)
+        //exit(0)
     }
-
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
+    
+    //***********************************************************************************
+    
+    func showCIFARImage(var cifarImageData:[Float]) {
 
-
+        let size = CGSize(width: 32, height: 32)
+        let rect = CGRect(origin: CGPoint(x: 0,y: 0), size: size)
+        
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        UIColor.whiteColor().setFill() // or custom color
+        UIRectFill(rect)
+        var image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        // CIFAR 10 images are 32x32 in 3 channels - RGB
+        // it is stored as 3 sequences of 32x32 = 1024 numbers in cifarImageData, i.e.
+        // red: numbers from position 0 to 1024 (not inclusive)
+        // green: numbers from position 1024 to 2048 (not inclusive)
+        // blue: numbers from position 2048 to 3072 (not inclusive)
+        for i in 0..<32 {
+            for j in 0..<32 {
+                let r = UInt8(cifarImageData[i*32 + j])
+                let g = UInt8(cifarImageData[32*32 + i*32 + j])
+                let b = UInt8(cifarImageData[2*32*32 + i*32 + j])
+                
+                // used to set pixels - RGBA into an UIImage
+                // for more info about RGBA check out https://en.wikipedia.org/wiki/RGBA_color_space
+                image = image.setPixelColorAtPoint(CGPoint(x: j,y: i), color: UIImage.RawColorType(r,g,b,255))!
+                
+                // used to read pixels - RGBA from an UIImage
+                var color = image.getPixelColorAtLocation(CGPoint(x:i, y:j))
+            }
+        }
+        print(image.size)
+        
+        // Displaying original image.
+        let originalImageView:UIImageView = UIImageView(frame: CGRectMake(20, 20, image.size.width, image.size.height))
+        originalImageView.image = image
+        self.view.addSubview(originalImageView)
+    }
+    
+    
+    
 }

--- a/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp.xcodeproj/project.pbxproj
+++ b/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		6B2942FE1C73CEBB0002721C /* DeepNetwork+Classify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2942F81C73CEBB0002721C /* DeepNetwork+Classify.swift */; };
 		6B2942FF1C73CEBB0002721C /* DeepNetwork+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2942F91C73CEBB0002721C /* DeepNetwork+JSON.swift */; };
 		6B2943001C73CEBB0002721C /* DeepNetwork+SetupNetworkFromDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2942FA1C73CEBB0002721C /* DeepNetwork+SetupNetworkFromDict.swift */; };
+		6B57D6321C82E6610082387B /* UIImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B57D6311C82E6610082387B /* UIImageExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -48,6 +49,7 @@
 		6B2942F81C73CEBB0002721C /* DeepNetwork+Classify.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DeepNetwork+Classify.swift"; sourceTree = "<group>"; };
 		6B2942F91C73CEBB0002721C /* DeepNetwork+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DeepNetwork+JSON.swift"; sourceTree = "<group>"; };
 		6B2942FA1C73CEBB0002721C /* DeepNetwork+SetupNetworkFromDict.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DeepNetwork+SetupNetworkFromDict.swift"; sourceTree = "<group>"; };
+		6B57D6311C82E6610082387B /* UIImageExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,6 +86,7 @@
 		6B2942D51C73CCF80002721C /* tvOSDeepLearningKitApp */ = {
 			isa = PBXGroup;
 			children = (
+				6B57D6301C82E6290082387B /* ThirdParty */,
 				6B2942D61C73CCF80002721C /* AppDelegate.swift */,
 				6B2942D81C73CCF80002721C /* ViewController.swift */,
 				6B2942F51C73CEBB0002721C /* conv1.json */,
@@ -103,6 +106,14 @@
 				6B2942DF1C73CCF80002721C /* Info.plist */,
 			);
 			path = tvOSDeepLearningKitApp;
+			sourceTree = "<group>";
+		};
+		6B57D6301C82E6290082387B /* ThirdParty */ = {
+			isa = PBXGroup;
+			children = (
+				6B57D6311C82E6610082387B /* UIImageExtension.swift */,
+			);
+			name = ThirdParty;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -186,6 +197,7 @@
 				6B2942F31C73CEB20002721C /* RectifierLayer.swift in Sources */,
 				6B2943001C73CEBB0002721C /* DeepNetwork+SetupNetworkFromDict.swift in Sources */,
 				6B2942FD1C73CEBB0002721C /* DeepNetwork.swift in Sources */,
+				6B57D6321C82E6610082387B /* UIImageExtension.swift in Sources */,
 				6B2942F21C73CEB20002721C /* PoolingLayer.swift in Sources */,
 				6B2942FC1C73CEBB0002721C /* ConvolutionLayer.swift in Sources */,
 				6B2942D71C73CCF80002721C /* AppDelegate.swift in Sources */,
@@ -330,6 +342,7 @@
 				6B2942E41C73CCF80002721C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/UIImageExtension.swift
+++ b/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/UIImageExtension.swift
@@ -1,0 +1,263 @@
+//
+//  UIImageExtension.swift
+//  ImageFun - original source project: https://github.com/kNeerajPro/ImagePixelFun
+//             cloned and adapted to Swift 2.x: https://github.com/DeepLearningKit/ImagePixelFun
+//  (ImageFun is also Apache 2.0 open source licence)
+//
+//  Created by Neeraj Kumar on 11/11/14.
+//  Copyright (c) 2014 Neeraj Kumar. All rights reserved.
+//  (minor adaptions to Swift 2.x by Amund Tveit - 2016)
+//
+
+import Foundation
+import UIKit
+
+private extension UIImage {
+    private func createARGBBitmapContext(inImage: CGImageRef) -> CGContext {
+        
+        //Get image width, height
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        
+        // Declare the number of bytes per row. Each pixel in the bitmap in this
+        // example is represented by 4 bytes; 8 bits each of red, green, blue, and
+        // alpha.
+        let bitmapBytesPerRow = Int(pixelsWide) * 4
+        let bitmapByteCount = bitmapBytesPerRow * Int(pixelsHigh)
+        
+        // Use the generic RGB color space.
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        
+        // Allocate memory for image data. This is the destination in memory
+        // where any drawing to the bitmap context will be rendered.
+        var bitmapData = UnsafeMutablePointer<UInt8>()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.PremultipliedFirst.rawValue)
+        
+        // Create the bitmap context. We want pre-multiplied ARGB, 8-bits
+        // per component. Regardless of what the source image format is
+        // (CMYK, Grayscale, and so on) it will be converted over to the format
+        // specified here by CGBitmapContextCreate.
+        let context = CGBitmapContextCreate(bitmapData, pixelsWide, pixelsHigh, 8, bitmapBytesPerRow, colorSpace, bitmapInfo.rawValue)
+        
+        return context!
+    }
+    
+    func sanitizePoint(point:CGPoint) {
+        let inImage:CGImageRef = self.CGImage!
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        precondition(CGRectContainsPoint(rect, point), "CGPoint passed is not inside the rect of image.It will give wrong pixel and may crash.")
+    }
+}
+
+
+// Internal functions exposed.Can be public.
+
+extension  UIImage {
+    public typealias RawColorType = (newRedColor:UInt8, newgreenColor:UInt8, newblueColor:UInt8,  newalphaValue:UInt8)
+    
+    
+    /*
+    Change the color of pixel at a certain point.If you want more control try block based method to modify pixels.
+    */
+    public func setPixelColorAtPoint(point:CGPoint, color: RawColorType) -> UIImage? {
+        self.sanitizePoint(point)
+        let inImage:CGImageRef = self.CGImage!
+        let context = self.createARGBBitmapContext(inImage)
+        
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        //Clear the context
+        CGContextClearRect(context, rect)
+        
+        // Draw the image to the bitmap context. Once we draw, the memory
+        // allocated for the context for rendering will then contain the
+        // raw image data in the specified color space.
+        CGContextDrawImage(context, rect, inImage)
+        
+        // Now we can get a pointer to the image data associated with the bitmap
+        // context.
+        var data = CGBitmapContextGetData(context)
+        var dataType = UnsafeMutablePointer<UInt8>(data)
+        
+        let offset = 4*((Int(pixelsWide) * Int(point.y)) + Int(point.x))
+        dataType[offset]   = color.newalphaValue
+        dataType[offset+1] = color.newRedColor
+        dataType[offset+2] = color.newgreenColor
+        dataType[offset+3] = color.newblueColor
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.PremultipliedFirst.rawValue)
+        
+        let bitmapBytesPerRow = Int(pixelsWide) * 4
+        let bitmapByteCount = bitmapBytesPerRow * Int(pixelsHigh)
+        
+        let finalcontext = CGBitmapContextCreate(data, pixelsWide, pixelsHigh, 8, bitmapBytesPerRow, colorSpace, bitmapInfo.rawValue)
+        
+        let imageRef = CGBitmapContextCreateImage(finalcontext)
+        return UIImage(CGImage: imageRef!, scale: self.scale,orientation: self.imageOrientation)
+        
+    }
+    
+    
+    /*
+    Get pixel color for a pixel in the image.
+    */
+    func getPixelColorAtLocation(point:CGPoint)->UIColor? {
+        self.sanitizePoint(point)
+        // Create off screen bitmap context to draw the image into. Format ARGB is 4 bytes for each pixel: Alpa, Red, Green, Blue
+        let inImage:CGImageRef = self.CGImage!
+        let context = self.createARGBBitmapContext(inImage)
+        
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        //Clear the context
+        CGContextClearRect(context, rect)
+        
+        // Draw the image to the bitmap context. Once we draw, the memory
+        // allocated for the context for rendering will then contain the
+        // raw image data in the specified color space.
+        CGContextDrawImage(context, rect, inImage)
+        
+        // Now we can get a pointer to the image data associated with the bitmap
+        // context.
+        let data = CGBitmapContextGetData(context)
+        let dataType = UnsafePointer<UInt8>(data)
+        
+        let offset = 4*((Int(pixelsWide) * Int(point.y)) + Int(point.x))
+        let alphaValue = dataType[offset]
+        let redColor = dataType[offset+1]
+        let greenColor = dataType[offset+2]
+        let blueColor = dataType[offset+3]
+        
+        let redFloat = CGFloat(redColor)/255.0
+        let greenFloat = CGFloat(greenColor)/255.0
+        let blueFloat = CGFloat(blueColor)/255.0
+        let alphaFloat = CGFloat(alphaValue)/255.0
+        
+        return UIColor(red: redFloat, green: greenFloat, blue: blueFloat, alpha: alphaFloat)
+        
+        // When finished, release the context
+        // Free image data memory for the context
+    }
+    
+    
+    // Get grayscale image from normal image.
+    
+    func getGrayScale() -> UIImage? {
+        let inImage:CGImageRef = self.CGImage!
+        let context = self.createARGBBitmapContext(inImage)
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        let bitmapBytesPerRow = Int(pixelsWide) * 4
+        let bitmapByteCount = bitmapBytesPerRow * Int(pixelsHigh)
+        
+        //Clear the context
+        CGContextClearRect(context, rect)
+        
+        // Draw the image to the bitmap context. Once we draw, the memory
+        // allocated for the context for rendering will then contain the
+        // raw image data in the specified color space.
+        CGContextDrawImage(context, rect, inImage)
+        
+        // Now we can get a pointer to the image data associated with the bitmap
+        // context.
+        
+        
+        var data = CGBitmapContextGetData(context)
+        var dataType = UnsafeMutablePointer<UInt8>(data)
+        let point: CGPoint = CGPointMake(0, 0)
+        
+        for var x = 0; x < Int(pixelsWide) ; x++ {
+            for var y = 0; y < Int(pixelsHigh) ; y++ {
+                let offset = 4*((Int(pixelsWide) * Int(y)) + Int(x))
+                let alpha = dataType[offset]
+                let red = dataType[offset+1]
+                let green = dataType[offset+2]
+                let blue = dataType[offset+3]
+                
+                let avg = (UInt32(red) + UInt32(green) + UInt32(blue))/3
+                
+                dataType[offset + 1] = UInt8(avg)
+                dataType[offset + 2] = UInt8(avg)
+                dataType[offset + 3] = UInt8(avg)
+            }
+        }
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.PremultipliedFirst.rawValue)
+        
+        let finalcontext = CGBitmapContextCreate(data, pixelsWide, pixelsHigh, 8,  bitmapBytesPerRow, colorSpace, bitmapInfo.rawValue)
+        
+        let imageRef = CGBitmapContextCreateImage(finalcontext)
+        return UIImage(CGImage: imageRef!, scale: self.scale,orientation: self.imageOrientation)
+    }
+    
+    
+    
+    // Defining the closure.
+    typealias ModifyPixelsClosure = (point:CGPoint, redColor:UInt8, greenColor:UInt8, blueColor:UInt8, alphaValue:UInt8)->(newRedColor:UInt8, newgreenColor:UInt8, newblueColor:UInt8,  newalphaValue:UInt8)
+    
+    
+    // Provide closure which will return new color value for pixel using any condition you want inside the closure.
+    
+    func applyOnPixels(closure:ModifyPixelsClosure) -> UIImage? {
+        let inImage:CGImageRef = self.CGImage!
+        let context = self.createARGBBitmapContext(inImage)
+        let pixelsWide = CGImageGetWidth(inImage)
+        let pixelsHigh = CGImageGetHeight(inImage)
+        let rect = CGRect(x:0, y:0, width:Int(pixelsWide), height:Int(pixelsHigh))
+        
+        let bitmapBytesPerRow = Int(pixelsWide) * 4
+        let bitmapByteCount = bitmapBytesPerRow * Int(pixelsHigh)
+        
+        //Clear the context
+        CGContextClearRect(context, rect)
+        
+        // Draw the image to the bitmap context. Once we draw, the memory
+        // allocated for the context for rendering will then contain the
+        // raw image data in the specified color space.
+        CGContextDrawImage(context, rect, inImage)
+        
+        // Now we can get a pointer to the image data associated with the bitmap
+        // context.
+        
+        
+        var data = CGBitmapContextGetData(context)
+        var dataType = UnsafeMutablePointer<UInt8>(data)
+        let point: CGPoint = CGPointMake(0, 0)
+        
+        for var x = 0; x < Int(pixelsWide) ; x++ {
+            for var y = 0; y < Int(pixelsHigh) ; y++ {
+                let offset = 4*((Int(pixelsWide) * Int(y)) + Int(x))
+                let alpha = dataType[offset]
+                let red = dataType[offset+1]
+                let green = dataType[offset+2]
+                let blue = dataType[offset+3]
+                //                let (newRedColor:UInt8, newGreenColor:UInt8?, newBlueColor:UInt8?, newAlphaValue:UInt8?)  =  closure(point: CGPointMake(CGFloat(x), CGFloat(y)), redColor: red, greenColor: green,  blueColor: blue, alphaValue: alpha)
+                let (newRedColor, newGreenColor, newBlueColor, newAlphaValue)  =  closure(point: CGPointMake(CGFloat(x), CGFloat(y)), redColor: red, greenColor: green,  blueColor: blue, alphaValue: alpha)
+                dataType[offset] = newAlphaValue
+                dataType[offset + 1] = newRedColor
+                dataType[offset + 2] = newGreenColor
+                dataType[offset + 3] = newBlueColor
+            }
+        }
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.PremultipliedFirst.rawValue)
+        
+        let finalcontext = CGBitmapContextCreate(data, pixelsWide, pixelsHigh, 8,  bitmapBytesPerRow, colorSpace, bitmapInfo.rawValue)
+        
+        let imageRef = CGBitmapContextCreateImage(finalcontext)
+        return UIImage(CGImage: imageRef!, scale: self.scale,orientation: self.imageOrientation)
+    }
+    
+}

--- a/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/ViewController.swift
+++ b/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/tvOSDeepLearningKitApp/ViewController.swift
@@ -19,8 +19,6 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view, typically from a nib.
     }
     
-    
-
     override func viewDidAppear(animated:Bool) {
         
         deepNetwork = DeepNetwork()
@@ -29,6 +27,8 @@ class ViewController: UIViewController {
         let conv1Layer = deepNetwork.loadJSONFile("conv1")!
         let image: [Float] = conv1Layer["input"] as! [Float]
         
+        // shows a tiny (32x32) CIFAR 10 image on screen
+        showCIFARImage(image)
         
         var randomimage = createFloatNumbersArray(image.count)
         for i in 0..<randomimage.count {
@@ -62,6 +62,47 @@ class ViewController: UIViewController {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
+    
+    //***********************************************************************************
+    
+    func showCIFARImage(var cifarImageData:[Float]) {
+        
+        let size = CGSize(width: 32, height: 32)
+        let rect = CGRect(origin: CGPoint(x: 0,y: 0), size: size)
+        
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        UIColor.whiteColor().setFill() // or custom color
+        UIRectFill(rect)
+        var image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        // CIFAR 10 images are 32x32 in 3 channels - RGB
+        // it is stored as 3 sequences of 32x32 = 1024 numbers in cifarImageData, i.e.
+        // red: numbers from position 0 to 1024 (not inclusive)
+        // green: numbers from position 1024 to 2048 (not inclusive)
+        // blue: numbers from position 2048 to 3072 (not inclusive)
+        for i in 0..<32 {
+            for j in 0..<32 {
+                let r = UInt8(cifarImageData[i*32 + j])
+                let g = UInt8(cifarImageData[32*32 + i*32 + j])
+                let b = UInt8(cifarImageData[2*32*32 + i*32 + j])
+                
+                // used to set pixels - RGBA into an UIImage
+                // for more info about RGBA check out https://en.wikipedia.org/wiki/RGBA_color_space
+                image = image.setPixelColorAtPoint(CGPoint(x: j,y: i), color: UIImage.RawColorType(r,g,b,255))!
+                
+                // used to read pixels - RGBA from an UIImage
+                var color = image.getPixelColorAtLocation(CGPoint(x:i, y:j))
+            }
+        }
+        print(image.size)
+        
+        // Displaying original image.
+        let originalImageView:UIImageView = UIImageView(frame: CGRectMake(20, 20, image.size.width, image.size.height))
+        originalImageView.image = image
+        self.view.addSubview(originalImageView)
+    }
+
 
 
 }


### PR DESCRIPTION
Added way to convert CIFAR 10 image format to UIImage, and also 

credit: adapted https://github.com/kNeerajPro/ImagePixelFun to Swift 2.x and included the UIImageExtensionSwift into DeepLearningKit
 (note: ImagePixelFun is licence compatible - same as DeepLearningKit with Apache 2.0)
